### PR TITLE
Add Catalog Builder

### DIFF
--- a/product-catalog/README.md
+++ b/product-catalog/README.md
@@ -1,0 +1,26 @@
+# Product Catalog
+
+This project defines the product catalog builder.  By listening to all events that describe new products and add that new information about products to the catalog table, it can create a catalog of all the products that have been offered and our latest best information about those products.
+
+To begin, the product catalog lambda processes the create product event.  As it expands, we expect to handle events describing the addition of product images to the system.
+
+Example product/create message:
+```
+{
+  "schema" : "com.nordstrom/product/create/1-0-0",
+  "id" : "4468125",
+  "brand" : "1.STATE",
+  "name" : "1.STATE Fringe Skirt",
+  "description" : "PAGE:/s/1-state-fringe-skirt/4468125"
+  "category": "A_CATEGORY"
+}
+```
+
+Example image/create message:
+```
+{
+  "schema" : "com.nordstrom/image/create/1-0-0",
+  "subjectId" : "product/4468125",
+  "image" : "s3://..."
+}
+```

--- a/product-catalog/catalog.js
+++ b/product-catalog/catalog.js
@@ -1,0 +1,213 @@
+'use strict';
+
+const AJV = require('ajv');
+const aws = require('aws-sdk'); // eslint-disable-line import/no-unresolved, import/no-extraneous-dependencies
+
+// TODO Get these from a better place later
+const eventSchema = require('./retail-stream-schema-ingress.json');
+const productCreateSchema = require('./product-create-schema.json');
+
+// TODO generalize this?  it is used by but not specific to this module
+const makeSchemaId = schema => `${schema.self.vendor}/${schema.self.name}/${schema.self.version}`;
+
+const eventSchemaId = makeSchemaId(eventSchema);
+const productCreateSchemaId = makeSchemaId(productCreateSchema);
+
+const ajv = new AJV();
+ajv.addSchema(eventSchema, eventSchemaId);
+ajv.addSchema(productCreateSchema, productCreateSchemaId);
+
+const dynamo = new aws.DynamoDB.DocumentClient();
+
+const constants = {
+  // self
+  MODULE: 'product-catalog/catalog.js',
+  // methods
+  METHOD_PUT_PRODUCT: 'putProduct',
+  // resources
+  TABLE_PRODUCT_CATALOG_NAME: process.env.TABLE_PRODUCT_CATALOG_NAME,
+};
+
+const impl = {
+  /**
+   * Put the given product in to the dynamo catalog.  Example event:
+   * {
+   *   "schema": "com.nordstrom/retail-stream/1-0-0",
+   *   "origin": "hello-retail/product-producer-automation",
+   *   "timeOrigin": "2017-01-12T18:29:25.171Z",
+   *   "data": {
+   *     "schema": "com.nordstrom/product/create/1-0-0",
+   *     "id": "4579874",
+   *     "brand": "POLO RALPH LAUREN",
+   *     "name": "Polo Ralph Lauren 3-Pack Socks",
+   *     "description": "PAGE:/s/polo-ralph-lauren-3-pack-socks/4579874",
+   *     "category": "Socks for Men"
+   *   }
+   * }
+   * @param product The product to put in the catalog.
+   * @param complete The callback to inform of completion, with optional error parameter.
+   */
+  putProduct: (event, complete) => {
+    const updated = Date.now();
+    const dbParams = {
+      TableName: constants.TABLE_PRODUCT_CATALOG_NAME,
+      Key: {
+        id: event.data.id,
+      },
+      UpdateExpression: [
+        'set',
+        '#c=if_not_exists(#c,:c),',
+        '#cb=if_not_exists(#cb,:cb),',
+        '#u=:u,',
+        '#ub=:ub,',
+        '#b=:b,',
+        '#n=:n,',
+        '#d=:d,',
+        '#cat=:cat',
+      ].join(' '),
+      ExpressionAttributeNames: {
+        '#c': 'created',
+        '#cb': 'createdBy',
+        '#u': 'updated',
+        '#ub': 'updatedBy',
+        '#b': 'brand',
+        '#n': 'name',
+        '#d': 'description',
+        '#cat': 'category',
+      },
+      ExpressionAttributeValues: {
+        ':c': updated,
+        ':cb': event.origin,
+        ':u': updated,
+        ':ub': event.origin,
+        ':b': event.data.brand,
+        ':n': event.data.name,
+        ':d': event.data.description,
+        ':cat': event.data.category,
+      },
+      ReturnValues: 'NONE',
+      ReturnConsumedCapacity: 'NONE',
+      ReturnItemCollectionMetrics: 'NONE',
+    };
+    dynamo.update(dbParams, (err) => {
+      if (err) {
+        complete(`${constants.MODULE} ${constants.METHOD_PUT_PRODUCT} - error updating DynamoDb: ${err}`);
+      } else {
+        complete();
+      }
+    });
+  },
+  /**
+   * Process the given event, reporting failure or success to the given callback
+   * @param event The event to validate and process with the appropriate logic
+   * @param complete The callback with which to report any errors
+   */
+  processEvent: (event, complete) => {
+    if (!event || !event.schema) {
+      complete('event or schema was not truthy.');
+    } else if (event.schema !== eventSchemaId) {
+      complete(`event did not have proper schema.  observed: '${event.schema}' expected: '${eventSchemaId}'`);
+    } else if (!ajv.validate(eventSchemaId, event)) {
+      complete(`could not validate event to '${eventSchemaId}' schema.  Errors: ${ajv.errorsText()}`);
+    } else if (event.data.schema === productCreateSchemaId) {
+      if (!ajv.validate(productCreateSchemaId, event.data)) {
+        complete(`could not validate event to '${productCreateSchema}' schema.  Errors: ${ajv.errorsText()}`);
+      } else {
+        impl.putProduct(event, complete);
+      }
+    } else {
+      console.log(`${constants.MODULE} ${constants.METHOD_PUT_PRODUCT
+        } - event with unsupported schema (${event.data.schema}) observed.`);
+      complete(); // TODO pass the above message once we are only receiving subscribed events
+    }
+  },
+};
+
+module.exports = {
+  /**
+   * Example Kinesis Event:
+   * {
+   *   "Records": [
+   *     {
+   *       "kinesis": {
+   *         "kinesisSchemaVersion": "1.0",
+   *         "partitionKey": "undefined",
+   *         "sequenceNumber": "49568749374218235080373793662003016116473266703358230578",
+   *         "data": "eyJzY2hlbWEiOiJjb20ubm9yZHN0cm9tL3JldGFpb[...]Y3NDQiLCJjYXRlZ29yeSI6IlN3ZWF0ZXJzIGZvciBNZW4ifX0=",
+   *         "approximateArrivalTimestamp": 1484245766.362
+   *       },
+   *       "eventSource": "aws:kinesis",
+   *       "eventVersion": "1.0",
+   *       "eventID": "shardId-000000000003:49568749374218235080373793662003016116473266703358230578",
+   *       "eventName": "aws:kinesis:record",
+   *       "invokeIdentityArn": "arn:aws:iam::515126931066:role/devProductCatalogReaderWriter",
+   *       "awsRegion": "us-west-2",
+   *       "eventSourceARN": "arn:aws:kinesis:us-west-2:515126931066:stream/devRetailStream"
+   *     },
+   *     {
+   *       "kinesis": {
+   *         "kinesisSchemaVersion": "1.0",
+   *         "partitionKey": "undefined",
+   *         "sequenceNumber": "49568749374218235080373793662021150003767486140978823218",
+   *         "data": "eyJzY2hlbWEiOiJjb20ubm9yZHN0cm9tL3JldGFpb[...]I3MyIsImNhdGVnb3J5IjoiU3dlYXRlcnMgZm9yIE1lbiJ9fQ==",
+   *         "approximateArrivalTimestamp": 1484245766.739
+   *       },
+   *       "eventSource": "aws:kinesis",
+   *       "eventVersion": "1.0",
+   *       "eventID": "shardId-000000000003:49568749374218235080373793662021150003767486140978823218",
+   *       "eventName": "aws:kinesis:record",
+   *       "invokeIdentityArn": "arn:aws:iam::515126931066:role/devProductCatalogReaderWriter",
+   *       "awsRegion": "us-west-2",
+   *       "eventSourceARN": "arn:aws:kinesis:us-west-2:515126931066:stream/devRetailStream"
+   *     }
+   *   ]
+   * }
+   * @param event The Kinesis event to decode and process.
+   * @param context The Lambda context object.
+   * @param callback The callback with which to call with results of event processing.
+   */
+  processEvent: (kinesisEvent, context, callback) => {
+    try {
+      console.log(`${constants.MODULE} ${constants.METHOD_PUT_PRODUCT
+        } - kinesis event received: ${JSON.stringify(kinesisEvent, null, 2)}`);
+      if (
+        kinesisEvent &&
+        kinesisEvent.Records &&
+        Array.isArray(kinesisEvent.Records)
+      ) {
+        let successes = 0;
+        const complete = (err) => {
+          if (err) {
+            throw new Error(err);
+          } else {
+            successes += 1;
+            if (successes === kinesisEvent.Records.length) {
+              console.log(`${constants.MODULE} ${constants.METHOD_PUT_PRODUCT
+                } - all ${kinesisEvent.Records.length} events processed successfully.`);
+              callback(null, true);
+            }
+          }
+        };
+        for (let i = 0; i < kinesisEvent.Records.length; i++) {
+          const record = kinesisEvent.Records[i];
+          if (
+            record.kinesis &&
+            record.kinesis.data
+          ) {
+            const payload = new Buffer(record.kinesis.data, 'base64').toString('ascii');
+            console.log(`${constants.MODULE} ${constants.METHOD_PUT_PRODUCT} - payload: ${payload}`);
+            impl.processEvent(JSON.parse(payload), complete);
+          }
+        }
+      } else {
+        callback(`${constants.MODULE} ${constants.METHOD_PUT_PRODUCT} - no records received.`);
+      }
+    } catch (ex) {
+      console.log(`${constants.MODULE} ${constants.METHOD_PUT_PRODUCT} - exception: ${JSON.stringify(ex, null, 2)}`);
+      callback(ex);
+    }
+  },
+};
+
+console.log(`${constants.MODULE} ${constants.METHOD_PUT_PRODUCT} - ENV: ${JSON.stringify(process.env, null, 2)}`);
+console.log(`${constants.MODULE} ${constants.METHOD_PUT_PRODUCT} - TABLE: ${constants.TABLE_PRODUCT_CATALOG_NAME}`);

--- a/product-catalog/catalog.spec.js
+++ b/product-catalog/catalog.spec.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/* eslint-env node, mocha */
+
+// const expect = require('chai').expect;
+
+// const catalog = require('./catalog.js');
+
+describe('Product Catalog Processor Unit Tests', () => {
+  let consoleLog;
+  before(() => {
+    consoleLog = console.log;
+    console.log = () => {};
+  });
+  after(() => {
+    console.log = consoleLog;
+  });
+  it('should have some tests', () => {
+  });
+});

--- a/product-catalog/package.json
+++ b/product-catalog/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "hello-retail-product-catalog",
+  "version": "0.0.1",
+  "description": "A stream processor that accumulates a catalog of our latest best knowledge regarding each product",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Nordstrom",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/Nordstrom/hello-retail/issues"
+  },
+  "homepage": "https://github.com/Nordstrom/hello-retail/product-catalog#readme",
+  "dependencies": {
+    "ajv": "^4.10.4"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^3.2.0"
+  }
+}

--- a/product-catalog/package.json
+++ b/product-catalog/package.json
@@ -4,7 +4,7 @@
   "description": "A stream processor that accumulates a catalog of our latest best knowledge regarding each product",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: tests executed by root hello-retail package.json\" && exit 1"
   },
   "author": "Nordstrom",
   "license": "Apache-2.0",
@@ -14,9 +14,5 @@
   "homepage": "https://github.com/Nordstrom/hello-retail/product-catalog#readme",
   "dependencies": {
     "ajv": "^4.10.4"
-  },
-  "devDependencies": {
-    "chai": "^3.5.0",
-    "mocha": "^3.2.0"
   }
 }

--- a/product-catalog/product-create-schema.json
+++ b/product-catalog/product-create-schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "self": {
+    "vendor": "com.nordstrom",
+    "name": "product/create",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "schema":  { "type": "string", "format": "url" },
+    "id": { "type": "string" },
+    "brand":  { "type": "string" },
+    "name":  { "type": "string" },
+    "description": { "type": "string" },
+    "category": { "type": "string"}
+  },
+  "required": [
+    "schema",
+    "id",
+    "brand",
+    "name",
+    "description",
+    "category"
+  ],
+  "additionalProperties": false
+}

--- a/product-catalog/retail-stream-schema-ingress.json
+++ b/product-catalog/retail-stream-schema-ingress.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "self": {
+    "vendor": "com.nordstrom",
+    "name": "retail-stream-ingress",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "schema":      { "type": "string", "format": "url" },
+    "followsFrom": { "type": "string" },
+    "origin":      { "type": "string" },
+    "timeOrigin":  { "type": "string", "format": "date-time" },
+    "data": {
+      "type": "object",
+      "properties": {
+        "schema": { "type": "string", "format": "url" }
+      },
+      "required": [
+        "schema"
+      ],
+      "additionalProperties": true
+    }
+  },
+  "required": [
+    "schema",
+    "origin",
+    "timeOrigin",
+    "data"
+  ],
+  "additionalProperties": false
+}

--- a/product-catalog/serverless.yml
+++ b/product-catalog/serverless.yml
@@ -25,6 +25,8 @@ functions:
         'Fn::ImportValue': 'hello-retail-stream:${self:custom.stage}:RetailStreamArn'
       STREAM_ROLE_ARN:
         'Fn::ImportValue': 'hello-retail-stream:${self:custom.stage}:RetailStreamReaderArn'
+      TABLE_PRODUCT_CATEGORY_NAME:
+        Ref: ProductCategory
       TABLE_PRODUCT_CATALOG_NAME:
         Ref: ProductCatalog
     events:
@@ -42,7 +44,22 @@ resources:
       Properties:
         LogGroupName: '/aws/lambda/${self:service}-${self:custom.stage}-catalog'
         RetentionInDays: 7
-    # Product Catalog
+    # Product Catalog Tables
+    ProductCategory:
+      Type: 'AWS::DynamoDB::Table'
+      Properties:
+        AttributeDefinitions:
+          - AttributeName: category
+            AttributeType: S
+        KeySchema:
+          - AttributeName: category
+            KeyType: HASH
+          - AttributeName: category
+            KeyType: RANGE
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1
+        TableName: '${self:custom.stage}-ProductCategory-${self:custom.productCatalogVersion}'
     ProductCatalog:
       Type: 'AWS::DynamoDB::Table'
       Properties:
@@ -75,7 +92,8 @@ resources:
             ProvisionedThroughput:
               ReadCapacityUnits: 1
               WriteCapacityUnits: 1
-    ProductCatalogReaderWriter: # role for this Lambda
+    # Product Catalog Roles
+    ProductCatalogReaderWriter: # role for the Catalog (Maintaining) Lambda
       Type: AWS::IAM::Role
       Properties:
         Path: /
@@ -120,20 +138,21 @@ resources:
                     - 'kinesis:ListStreams'
                   Resource:
                     'Fn::ImportValue': 'hello-retail-stream:${self:custom.stage}:RetailStreamArn'
-          - PolicyName: ReadFromCatalog
+          - PolicyName: WriteToCatalog
             PolicyDocument:
               Version: '2012-10-17'
               Statement:
                 -  Effect: 'Allow'
                    Action:
-                     - 'dynamo:GetItem'
-                     - 'dynamodb:BatchGetItem'
-                     - 'dynamodb:PutItem'
-                     - 'dynamodb:DeleteItem'
-                     - 'dynamodb:BatchWriteItem'
                      - 'dynamodb:UpdateItem'
-                     - 'dynamodb:Query'
-                     - 'dynamodb:Scan'
+                   Resource:
+                    'Fn::Join':
+                      - '/'
+                      - - 'arn:aws:dynamodb:${self:provider.region}:${self:custom.private.accountId}:table'
+                        - Ref: ProductCategory
+                -  Effect: 'Allow'
+                   Action:
+                     - 'dynamodb:UpdateItem'
                    Resource:
                     'Fn::Join':
                       - '/'
@@ -161,6 +180,14 @@ resources:
               Statement:
                 -  Effect: 'Allow'
                    Action:
+                     - 'dynamodb:Query'
+                   Resource:
+                    'Fn::Join':
+                      - '/'
+                      - - 'arn:aws:dynamodb:${self:provider.region}:${self:custom.private.accountId}:table'
+                        - Ref: ProductCategory
+                -  Effect: 'Allow'
+                   Action:
                      - 'dynamo:GetItem'
                      - 'dynamo:BatchGetItem'
                    Resource:
@@ -168,14 +195,39 @@ resources:
                       - '/'
                       - - 'arn:aws:dynamodb:${self:provider.region}:${self:custom.private.accountId}:table'
                         - Ref: ProductCatalog
+                -  Effect: 'Allow'
+                   Action:
+                     - 'dynamo:Query'
+                   Resource:
+                    'Fn::Join':
+                      - '/'
+                      - - 'arn:aws:dynamodb:${self:provider.region}:${self:custom.private.accountId}:table'
+                        - Ref: ProductCatalog
+                        - index
+                        - Category
   Outputs:
-    ProductCatalogName:
+    ProductCategoryTableName:
+      Description: The Name of the Product Catalog Table
+      Value:
+        Ref: ProductCategory
+      Export:
+        Name: '${self:service}:${self:custom.stage}:ProductCategoryTableName'
+    ProductCategoryTableArn:
+      Description: The ARN for the Product Catalog Table
+      Value:
+        'Fn::Join':
+          - '/'
+          - - 'arn:aws:dynamodb:${self:provider.region}:${self:custom.private.accountId}:table'
+            - Ref: ProductCategory
+      Export:
+        Name: '${self:service}:${self:custom.stage}:ProductCategoryTableArn'
+    ProductCatalogTableName:
       Description: The Name of the Product Catalog Table
       Value:
         Ref: ProductCatalog
       Export:
-        Name: '${self:service}:${self:custom.stage}:ProductCatalogName'
-    ProductCatalogArn:
+        Name: '${self:service}:${self:custom.stage}:ProductCatalogTableName'
+    ProductCatalogTableArn:
       Description: The ARN for the Product Catalog Table
       Value:
         'Fn::Join':
@@ -183,9 +235,20 @@ resources:
           - - 'arn:aws:dynamodb:${self:provider.region}:${self:custom.private.accountId}:table'
             - Ref: ProductCatalog
       Export:
-        Name: '${self:service}:${self:custom.stage}:ProductCatalogArn'
+        Name: '${self:service}:${self:custom.stage}:ProductCatalogTableArn'
+    ProductCatalogTableCategoryIndexArn:
+      Description: The ARN for the Product Catalog Table's Category Index
+      Value:
+        'Fn::Join':
+          - '/'
+          - - 'arn:aws:dynamodb:${self:provider.region}:${self:custom.private.accountId}:table'
+            - Ref: ProductCatalog
+            - index
+            - Category
+      Export:
+        Name: '${self:service}:${self:custom.stage}:ProductCatalogTableCategoryIndexArn'
     ProductCatalogReaderArn:
-      Description: The ARN for a Product Catalog Reader Role
+      Description: The Role ARN for a Product Catalog Reader
       Value:
         'Fn::GetAtt': [ ProductCatalogReader, Arn ]
       Export:

--- a/product-catalog/serverless.yml
+++ b/product-catalog/serverless.yml
@@ -40,7 +40,7 @@ resources:
     CatalogLogGroup:
       Type: 'AWS::Logs::LogGroup'
       Properties:
-        LogGroupName: '/aws/lambda/hello-retail-product-catalog-dev-catalog'
+        LogGroupName: '/aws/lambda/${self:service}-${self:custom.stage}-catalog'
         RetentionInDays: 7
     # Product Catalog
     ProductCatalog:

--- a/product-catalog/serverless.yml
+++ b/product-catalog/serverless.yml
@@ -1,0 +1,173 @@
+frameworkVersion: '>=1.0.0 <2.0.0'
+
+service: hello-retail-product-catalog
+
+custom:
+  stage: ${opt:stage, self:provider.stage, self:custom.private.stage}
+  private: ${file(../private.yml)}
+  productCatalogVersion: 1
+
+provider:
+  name: aws
+  deploymentBucket: com.${self:custom.private.company}.${self:custom.private.team}.serverless.${self:provider.region}
+  runtime: nodejs4.3
+  profile: ${self:custom.private.profile}
+  region: ${self:custom.private.region}
+
+functions:
+  catalog:
+    role:
+      'Fn::GetAtt': [ ProductCatalogReaderWriter, Arn ]
+    handler: catalog.processEvent
+    environment:
+      STAGE: ${self:custom.stage}
+      STREAM_ARN:
+        'Fn::ImportValue': 'hello-retail-stream:${self:custom.stage}:RetailStreamArn'
+      STREAM_ROLE_ARN:
+        'Fn::ImportValue': 'hello-retail-stream:${self:custom.stage}:RetailStreamReaderArn'
+      TABLE_PRODUCT_CATALOG_NAME:
+        Ref: ProductCatalog
+    events:
+      - stream:
+          arn: 'arn:aws:kinesis:${self:provider.region}:${self:custom.private.accountId}:stream/${self:custom.stage}RetailStream' # replace this with the below, once supported by Serverless
+#            'Fn::ImportValue': 'hello-retail-stream:${self:custom.stage}:RetailStreamArn'
+          enabled: true
+          startingPosition: 'TRIM_HORIZON'
+
+resources:
+  Resources:
+    # Log Group
+    CatalogLogGroup:
+      Type: 'AWS::Logs::LogGroup'
+      Properties:
+        LogGroupName: '/aws/lambda/hello-retail-product-catalog-dev-catalog'
+        RetentionInDays: 7
+    # Product Catalog
+    ProductCatalog:
+      Type: 'AWS::DynamoDB::Table'
+      Properties:
+        AttributeDefinitions:
+          - AttributeName: id
+            AttributeType: S
+        KeySchema:
+          - AttributeName: id
+            KeyType: HASH
+        ProvisionedThroughput:
+          ReadCapacityUnits: 1
+          WriteCapacityUnits: 1
+        TableName: '${self:custom.stage}-ProductCatalog-${self:custom.productCatalogVersion}'
+    ProductCatalogReaderWriter: # role for this Lambda
+      Type: AWS::IAM::Role
+      Properties:
+        Path: /
+        RoleName: ${self:custom.stage}ProductCatalogReaderWriter
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action: sts:AssumeRole
+              Principal:
+                AWS: # role ARNs that are allowed to write to the Product Catalog
+                  - 'arn:aws:iam::${self:custom.private.accountId}:role/${self:custom.private.teamRole}'
+            - Effect: Allow
+              Action: sts:AssumeRole
+              Principal:
+                Service: 'lambda.amazonaws.com'
+        ManagedPolicyArns:
+          - ${self:custom.private.teamPolicy}
+        Policies:
+          - PolicyName: CreateAndWriteToLogStream
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: 'Allow'
+                  Action:
+                    - 'logs:CreateLogStream'
+                    - 'logs:PutLogEvents'
+                  Resource:
+                    'Fn::Join':
+                      - ':'
+                      - - 'Fn::GetAtt': [ CatalogLogGroup, Arn ]
+                        - '*'
+          - PolicyName: ReadFromKinesis
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: 'Allow'
+                  Action:
+                    - 'kinesis:GetRecords'
+                    - 'kinesis:GetShardIterator'
+                    - 'kinesis:DescribeStream'
+                    - 'kinesis:ListStreams'
+                  Resource:
+                    'Fn::ImportValue': 'hello-retail-stream:${self:custom.stage}:RetailStreamArn'
+          - PolicyName: ReadFromCatalog
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                -  Effect: 'Allow'
+                   Action:
+                     - 'dynamo:GetItem'
+                     - 'dynamodb:BatchGetItem'
+                     - 'dynamodb:PutItem'
+                     - 'dynamodb:DeleteItem'
+                     - 'dynamodb:BatchWriteItem'
+                     - 'dynamodb:UpdateItem'
+                     - 'dynamodb:Query'
+                     - 'dynamodb:Scan'
+                   Resource:
+                    'Fn::Join':
+                      - '/'
+                      - - 'arn:aws:dynamodb:${self:provider.region}:${self:custom.private.accountId}:table'
+                        - Ref: ProductCatalog
+    ProductCatalogReader: # role for consumers of the catalog
+      Type: AWS::IAM::Role
+      Properties:
+        Path: /
+        RoleName: ${self:custom.stage}ProductCatalogReader
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Principal:
+                AWS: # role ARNs that are allowed to read from the Product Catalog
+                  - 'arn:aws:iam::${self:custom.private.accountId}:role/${self:custom.private.teamRole}'
+              Action: sts:AssumeRole
+        ManagedPolicyArns:
+          - ${self:custom.private.teamPolicy}
+        Policies:
+          - PolicyName: ReadFromCatalog
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                -  Effect: 'Allow'
+                   Action:
+                     - 'dynamo:GetItem'
+                     - 'dynamo:BatchGetItem'
+                   Resource:
+                    'Fn::Join':
+                      - '/'
+                      - - 'arn:aws:dynamodb:${self:provider.region}:${self:custom.private.accountId}:table'
+                        - Ref: ProductCatalog
+  Outputs:
+    ProductCatalogName:
+      Description: The Name of the Product Catalog Table
+      Value:
+        Ref: ProductCatalog
+      Export:
+        Name: '${self:service}:${self:custom.stage}:ProductCatalogName'
+    ProductCatalogArn:
+      Description: The ARN for the Product Catalog Table
+      Value:
+        'Fn::Join':
+          - '/'
+          - - 'arn:aws:dynamodb:${self:provider.region}:${self:custom.private.accountId}:table'
+            - Ref: ProductCatalog
+      Export:
+        Name: '${self:service}:${self:custom.stage}:ProductCatalogArn'
+    ProductCatalogReaderArn:
+      Description: The ARN for a Product Catalog Reader Role
+      Value:
+        'Fn::GetAtt': [ ProductCatalogReader, Arn ]
+      Export:
+        Name: '${self:service}:${self:custom.stage}:ProductCatalogReaderArn'

--- a/product-catalog/serverless.yml
+++ b/product-catalog/serverless.yml
@@ -54,8 +54,6 @@ resources:
         KeySchema:
           - AttributeName: category
             KeyType: HASH
-          - AttributeName: category
-            KeyType: RANGE
         ProvisionedThroughput:
           ReadCapacityUnits: 1
           WriteCapacityUnits: 1
@@ -81,14 +79,14 @@ resources:
           - IndexName: Category
             KeySchema:
               - AttributeName: category
-                KeyType: hash
+                KeyType: HASH
               - AttributeName: name
-                KeyType: range
+                KeyType: RANGE
             Projection:
               ProjectionType: INCLUDE
-            NonKeyAttributes:
-              - brand
-              - description
+              NonKeyAttributes:
+                - brand
+                - description
             ProvisionedThroughput:
               ReadCapacityUnits: 1
               WriteCapacityUnits: 1


### PR DESCRIPTION
Add a serverless service that builds a product catalog.
This service defines a dynamodb table for materializing our last best understanding of the product catalog into.
This service defines a lambda that processes product/create events on the stream to populate the catalog.

README.md describes the service
serverless.yml defines the service
package.json brings in the schema validator
catalog.js defines the code for the lambda
catalog.spec.js defines a shell into which we can pour test implementations

Temporary: // TODO get from better source
  copy of the retail-stream-schema-ingress.json schema
  copy of the product-create-schema.json