### PR TITLE
Only Succeed Message Failures, Fix Update, Improve Logging

### DIFF
--- a/product-catalog/serverless.yml
+++ b/product-catalog/serverless.yml
@@ -18,7 +18,7 @@ functions:
   catalog:
     role:
       'Fn::GetAtt': [ ProductCatalogReaderWriter, Arn ]
-    handler: catalog.processEvent
+    handler: catalog.processKinesisEvent
     environment:
       STAGE: ${self:custom.stage}
       STREAM_ARN:


### PR DESCRIPTION
This was implemented with the assumption that we would be responsible and not place bad messages on the stream.  Not sure this was ever a safe assumption.  This version ignores invalid messages but fails on all other errors.

Fix update bug.

Improve logging for correctness, better traceability, and readability


Details
0. Only Succeed Message Failures:
  a. Add "bad msg:" error prefix.
  b. Use "bad msg:" error prefix to only succeed failures based on bad messages received.  (i.e. still fail for real failures in downstream systems)

1. Fix Update:
  a. Fix the update by removing the key from the update statement.

2. Improve Logging
  a. Rename duplicated method name processEvent (was both in export and impl scope) to processEvent and processKinesisEvent.
  b. Correct the declaration of source method in error messages throughout (including use of now disambiguated method names)
  c. Improve environment and constants listing