### PR TITLE
Throw an error rather than a string.

### DIFF
--- a/product-photos/3.receive/receive.js
+++ b/product-photos/3.receive/receive.js
@@ -273,7 +273,7 @@ const impl = {
     }
     return stepfunctions.sendTaskSuccess(params).promise().then(
       () => BbPromise.resolve(taskEvent),
-      err => BbPromise.reject(`Error sending success to Step Function: ${err}`) // eslint-disable-line comma-dangle
+      err => BbPromise.reject(new ServerError(`Error sending success to Step Function: ${err}`)) // eslint-disable-line comma-dangle
     )
   },
   userErrorResp: (error) => {


### PR DESCRIPTION
Otherwise the string will not be properly handled or have a stack trace, et cetera, in the case of an error calling sendTaskSuccess (confirming completion of step function assignment)